### PR TITLE
Bind init sql into entrypoint folder

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -27,6 +27,9 @@ services:
       POSTGRES_PASSWORD: postgres
       POSTGRES_DB: testdb
     volumes:
+      - type: bind
+        source: ../sql/initial-setup.sql
+        target: /docker-entrypoint-initdb.d/initial-setup.sql
       - postgres-data:/var/lib/postgresql/data
   redis:
     image: redis:6.0-alpine


### PR DESCRIPTION
It will be automatically run by postgres container if db does not exist yet.