### PR TITLE
Add mongo entrypoint script inializing a single replica set

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -3,7 +3,7 @@ version: '3.6'
 services:
   mongodb:
     image: mongo:4.4.3
-    command: --replSet rs0
+    command: --replSet "rs0"
     container_name: mongodb-wall
     ports:
       - 27017:27017

--- a/docker/mongo-entrypoint/init.js
+++ b/docker/mongo-entrypoint/init.js
@@ -1,0 +1,7 @@
+db.runCommand({ replSetInitiate : {
+        _id : "rs0",
+        members: [
+            { _id: 0, host: "localhost:27017" },
+        ]
+    } })
+rs.status()


### PR DESCRIPTION
Apparently running `db.runCommand(replSetInitiate: <config>)` from a startup script will work instead of `rs.initiate()`

Using these threads for info. 

https://github.com/docker-library/mongo/issues/339
https://github.com/Deffiss/testenvironment-docker/pull/31